### PR TITLE
Modified to use the scheduled task option in WinRM transport

### DIFF
--- a/.kitchen.azurerm.yml
+++ b/.kitchen.azurerm.yml
@@ -8,7 +8,7 @@ driver_config:
   machine_size: "Standard_D4"
 
 provisioner:
-  name: chef_zero_scheduled_task
+  name: chef_zero
 
 platforms:
   - name: windows-2012r2
@@ -17,6 +17,7 @@ platforms:
     transport:
       name: winrm
       username: azure
+      elevated: true
 
 suites:
   - name: default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,3 +12,5 @@ default['sql_server']['accept_eula'] = true
 default['sql_server']['version'] = '2012'
 default['sql_server']['instance_name']  = 'MSSQLSERVER'
 default['sql_server']['update_enabled'] = false
+
+set['sql_server']['sysadmins'] = 'BUILTIN\ADMINISTRATORS'


### PR DESCRIPTION
Modified the provisioner to be `chef_zero` and added `elevated: true` to the transport.

This is so that SQL is installed under an elevated account.  This is available in test kitchen 1.8.0 onwards.
